### PR TITLE
refac: preferences and tour filtering

### DIFF
--- a/src/Explorer.API/Controllers/Author/TourController.cs
+++ b/src/Explorer.API/Controllers/Author/TourController.cs
@@ -164,5 +164,14 @@ namespace Explorer.API.Controllers.Author
 				return CreateResponse(Result.Fail("Invalid Base64 string for the image."));
 			}
 		}
-	}
+
+        [AllowAnonymous]
+        [Authorize(Policy = "touristPolicy")]
+        [HttpGet("tourist/{touristId:long}/preferences/{page:int}/{pageSize:int}")]
+        public ActionResult<PagedResult<TourCardDto>> GetToursByActivePreferencePaged(long touristId, int page, int pageSize)
+        {
+            var result = _tourService.GetToursByActivePreferencePaged(touristId, page, pageSize);
+            return CreateResponse(result);
+        }
+    }
 }

--- a/src/Explorer.API/Controllers/Tourist/PreferenceController.cs
+++ b/src/Explorer.API/Controllers/Tourist/PreferenceController.cs
@@ -70,6 +70,29 @@ namespace Explorer.API.Controllers.Tourist
             return Ok(result.Value);
         }
 
+        [HttpPost("activate/{Id:long}")]
+        public ActionResult ActivatePreference(long Id)
+        {
+            var result = _preferenceService.ActivatePreference(Id);
+            if (result.IsSuccess)
+            {
+                return Ok("Preference activated successfully.");
+            }
+            return NotFound(result.Errors);
+        }
+
+        [HttpPost("deactivate/{Id:long}")]
+        public ActionResult DeactivatePreference(long Id)
+        {
+            var result = _preferenceService.DeactivatePreference(Id);
+            if (result.IsSuccess)
+            {
+                return Ok("Preference deactivated successfully.");
+            }
+            return NotFound(result.Errors);
+        }
+
+
 
 
     }

--- a/src/Modules/Tours/Explorer.Tours.API/Dtos/PreferenceDto.cs
+++ b/src/Modules/Tours/Explorer.Tours.API/Dtos/PreferenceDto.cs
@@ -1,5 +1,6 @@
 ﻿using Explorer.BuildingBlocks.Core.Domain;
 using System.Collections.Generic;
+using Explorer.Tours.API.Enum;
 
 namespace Explorer.Tours.API.Dtos
 {
@@ -8,12 +9,14 @@ namespace Explorer.Tours.API.Dtos
     {
         public long Id { get; set; }
         public int TouristId { get; set; }
-        public TourDifficulty PreferredDifficulty { get; set; }
+        public TourLevel PreferredDifficulty { get; set; }
         public int WalkRating { get; set; }
         public int BikeRating { get; set; }
         public int CarRating { get; set; }
         public int BoatRating { get; set; }
         public List<string> InterestTags { get; set; }
+        public bool isActive { get; set; }
+
 
     }
 

--- a/src/Modules/Tours/Explorer.Tours.API/Public/Administration/ITourService.cs
+++ b/src/Modules/Tours/Explorer.Tours.API/Public/Administration/ITourService.cs
@@ -25,5 +25,6 @@ public interface ITourService {
     Result<TourTouristDto> GetForTouristById(long id, long touristId);
     Result ArchiveTour(long tourId);
 	Task<List<TourDto>> GetToursByIds(List<long> tourIds);
+    Result<PagedResult<TourCardDto>> GetToursByActivePreferencePaged(long touristId, int page, int pageSize);
 
 }

--- a/src/Modules/Tours/Explorer.Tours.API/Public/IPreferenceService.cs
+++ b/src/Modules/Tours/Explorer.Tours.API/Public/IPreferenceService.cs
@@ -24,8 +24,12 @@ namespace Explorer.Tours.API.Public
 
         Task<Result<PagedResult<PreferenceDto>>> GetPagedByUserId(long userId, int pageIndex, int pageSize);
 
+        Result ActivatePreference(long preferenceId);
 
-        //Task<Result<PagedResult<PreferenceDto>>> GetPagedByUserId(long userId, int pageIndex, int pageSize);
+        Result DeactivatePreference(long preferenceId);
+
+        Result DeletePreference(long preferenceId);
+        Result<List<PreferenceDto>> GetAllByTouristId(long touristId);
 
 
 

--- a/src/Modules/Tours/Explorer.Tours.Core/Domain/Preference.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/Domain/Preference.cs
@@ -1,4 +1,5 @@
 ﻿using Explorer.BuildingBlocks.Core.Domain;
+using Explorer.Tours.API.Enum;
 using System.Collections.Generic;
 
 namespace Explorer.Tours.Core.Domain
@@ -7,17 +8,19 @@ namespace Explorer.Tours.Core.Domain
     public class Preference : Entity
     {
         public long TouristId { get; private set; }
-        public TourDifficulty PreferredDifficulty { get; private set; }
+        public TourLevel PreferredDifficulty { get; private set; }
         public int WalkRating { get; private set; }
         public int BikeRating { get; private set; }
         public int CarRating { get; private set; }
         public int BoatRating { get; private set; }
         public List<string> InterestTags { get; private set; }
+        public bool IsActive { get; private set; }
 
-        public Preference(long touristId, TourDifficulty preferredDifficulty, int walkRating, int bikeRating, int carRating, int boatRating, List<string> interestTags)
+
+        public Preference(long touristId, TourLevel preferredDifficulty, int walkRating, int bikeRating, int carRating, int boatRating, List<string> interestTags)
         {
 
-            if (!Enum.IsDefined(typeof(TourDifficulty), preferredDifficulty))
+            if (!Enum.IsDefined(typeof(TourLevel), preferredDifficulty))
             {
                 throw new ArgumentException("Invalid tour difficulty. Allowed values are BEGINNER, INTERMEDIATE, and ADVANCED.");
             }
@@ -49,9 +52,20 @@ namespace Explorer.Tours.Core.Domain
             BikeRating = bikeRating;
             CarRating = carRating;
             BoatRating = boatRating;
-            InterestTags = interestTags ?? new List<string>(); // Postavlja praznu listu ako je null
+            InterestTags = interestTags ?? new List<string>();
+            IsActive = false;
+
         }
 
+        public void Activate()
+        {
+            IsActive = true;
+        }
+
+        public void Deactivate()
+        {
+            IsActive = false;
+        }
 
         public enum TourDifficulty
         {

--- a/src/Modules/Tours/Explorer.Tours.Core/Domain/RepositoryInterfaces/IPreferenceRepository.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/Domain/RepositoryInterfaces/IPreferenceRepository.cs
@@ -1,0 +1,16 @@
+﻿using FluentResults;
+using Explorer.Preferences.Core.Domain;
+using Explorer.Tours.Core.Domain;
+using Explorer.BuildingBlocks.Core.UseCases;
+
+namespace Explorer.Preferences.Core.Domain.RepositoryInterfaces;
+
+public interface IPreferenceRepository : ICrudRepository<Preference>
+{
+    Preference? GetById(long id);
+    Preference AddPreference(Preference preference);
+    Result ActivatePreference(long preferenceId);
+    Result DeactivatePreference(long preferenceId);
+    List<Preference> GetByTouristId(long touristId);
+    List<Preference> GetAll();
+}

--- a/src/Modules/Tours/Explorer.Tours.Core/UseCases/Administration/TourService.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/UseCases/Administration/TourService.cs
@@ -16,6 +16,7 @@ using Explorer.Tours.API.Internal;
 using Explorer.Payments.API.Internal;
 using Explorer.Tours.API.Dtos.TourLeaderboard;
 using Explorer.Stakeholders.API.Internal;
+using Explorer.Preferences.Core.Domain.RepositoryInterfaces;
 
 namespace Explorer.Tours.Core.UseCases.Administration;
 
@@ -28,10 +29,11 @@ public class TourService : ITourService {
     private readonly ITourExecutionRepository _tourExecutionRepository;
     private readonly ITourReviewRepository _tourReviewRepository;
     private readonly IUserProfileServiceInternal _userProfileService;
+    private readonly IPreferenceRepository _preferenceRepository;
 
     public TourService(ITourRepository repository, IUserRepository userRepository , IMapper mapper,
         IInternalShoppingCartService shoppingCartRepository, ITourExecutionRepository tourExecutionRepository,
-        ITourReviewRepository tourReviewRepository, IUserProfileServiceInternal userProfileService)
+        ITourReviewRepository tourReviewRepository, IUserProfileServiceInternal userProfileService, IPreferenceRepository preferenceRepository)
     {
         _tourRepository = repository;
         _tourExecutionRepository = tourExecutionRepository;
@@ -42,6 +44,7 @@ public class TourService : ITourService {
         equipmentMapper = new MapperConfiguration(cfg => cfg.CreateMap<Equipment, EquipmentDto>()).CreateMapper();
         _tourReviewRepository = tourReviewRepository;
         _userProfileService = userProfileService;
+        _preferenceRepository = preferenceRepository;
     }
 
     public Result<TourDto> GetById(long id) {
@@ -423,6 +426,72 @@ public class TourService : ITourService {
 			Description = t.Description
 		}).ToList();
 	}
+
+    public Result<PagedResult<TourCardDto>> GetToursByActivePreferencePaged(long touristId, int page, int pageSize)
+    {
+        try
+        {
+            var preferences = _preferenceRepository.GetByTouristId(touristId);
+            var activePreference = preferences.FirstOrDefault(p => p.IsActive);
+
+            if (activePreference == null)
+            {
+                return Result.Fail<PagedResult<TourCardDto>>("No active preferences found.");
+            }
+
+            var pagedTours = _tourRepository.GetPublishedPaged(page, pageSize);
+
+            var filteredTours = pagedTours.Where(tour =>
+                (tour.Level == activePreference.PreferredDifficulty) ||
+                (tour.TransportDurations.Any(td =>
+                    (activePreference.WalkRating > 0 && td.Transport == TourTransport.OnFoot) ||
+                    (activePreference.BikeRating > 0 && td.Transport == TourTransport.Bicycle) ||
+                    (activePreference.CarRating > 0 && td.Transport == TourTransport.Car))) ||
+                (activePreference.InterestTags.Any(tag =>
+                    !string.IsNullOrEmpty(tour.Tags) && tour.Tags.Split(',').Contains(tag.Trim())))
+            ).ToList();
+
+            var tourDtos = filteredTours.Select(tour =>
+            {
+                var price = new MoneyDto(tour.Price.Amount, tour.Price.Currency);
+                var keypoint = tour.KeyPoints.FirstOrDefault();  
+                var keyPointDto = keypoint == null ? null : new KeyPointDto(keypoint.Id, keypoint.Latitude, keypoint.Longitude, keypoint.Name, keypoint.Description, keypoint.TourId)
+                {
+                    Image = keypoint?.Image != null ? Base64Converter.ConvertFromByteArray(keypoint.Image) : null
+                };
+
+                var reviews = _tourReviewRepository.GetByTourId((int)tour.Id);
+                double? averageRating = reviews.IsSuccess && reviews.Value.Any()
+                    ? reviews.Value.Average(r => r.Rating)
+                    : null;
+
+                return new TourCardDto(
+                    tour.Id,
+                    tour.Name,
+                    tour.Tags,
+                    tour.Level,
+                    tour.Status,
+                    price,
+                    tour.AuthorId,
+                    tour.Length,
+                    tour.PublishedTime,
+                    keyPointDto,
+                    averageRating
+                );
+            }).ToList();
+
+            var pagedResult = new PagedResult<TourCardDto>(tourDtos, filteredTours.Count); 
+
+            return Result.Ok(pagedResult);
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail<PagedResult<TourCardDto>>($"An error occurred while filtering tours: {ex.Message}");
+        }
+    }
+
+
+
 
 }
 

--- a/src/Modules/Tours/Explorer.Tours.Core/UseCases/PreferenceService.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/UseCases/PreferenceService.cs
@@ -4,6 +4,7 @@ using Explorer.Tours.API.Dtos;
 using Explorer.Tours.API.Public;
 using Explorer.Tours.Core.Domain;
 using FluentResults;
+using Explorer.Preferences.Core.Domain.RepositoryInterfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,15 +17,17 @@ namespace Explorer.Tours.Core.UseCases
     public class PreferenceService : CrudService<PreferenceDto, Preference>, IPreferenceService
     {
         private readonly IMapper _mapper;
+        private readonly IPreferenceRepository _preferenceRepository;
 
-        public PreferenceService(ICrudRepository<Preference> repository, IMapper mapper) : base(repository, mapper) {
 
+        public PreferenceService(IPreferenceRepository preferenceRepository, IMapper mapper) : base(preferenceRepository, mapper)
+        {
             _mapper = mapper;
+            _preferenceRepository = preferenceRepository;
         }
 
         public Result<List<PreferenceDto>> GetAll()
         {
-            // Ako želite sve rezultate, možete koristiti int.MaxValue kao veličinu stranice
             var pagedResult = GetPaged(1, int.MaxValue);
 
             if (pagedResult.IsFailed)
@@ -40,7 +43,6 @@ namespace Explorer.Tours.Core.UseCases
              return base.GetPaged(pageIndex, pageSize);
          }
 
-        // Metoda za paginaciju po ID-u korisnika
         public async Task<Result<PagedResult<PreferenceDto>>> GetPagedByUserId(long touristId, int pageIndex, int pageSize)
         {
             var pagedResult = base.GetPaged(pageIndex, pageSize);
@@ -50,19 +52,77 @@ namespace Explorer.Tours.Core.UseCases
                 return Result.Fail<PagedResult<PreferenceDto>>(pagedResult.Errors);
             }
 
-            // Filtriranje rezultata prema ID-u turiste
             var userPreferences = pagedResult.Value.Results
                                                .Where(p => p.TouristId == touristId)
                                                .ToList();
 
             var totalCount = userPreferences.Count;
 
-            // Ove dve linije možda treba prilagoditi u zavisnosti od vašeg Mapper-a
             var preferenceDtos = _mapper.Map<List<PreferenceDto>>(userPreferences);
             var pagedResultForUser = new PagedResult<PreferenceDto>(preferenceDtos, totalCount);
 
             return Result.Ok(pagedResultForUser);
         }
+
+        public Result ActivatePreference(long preferenceId)
+        {
+            var preference = _preferenceRepository.GetById(preferenceId);
+            if (preference == null)
+            {
+                return Result.Fail("Preference not found.");
+            }
+
+            preference.Activate();
+            _preferenceRepository.Update(preference);
+            return Result.Ok();
+        }
+
+        public Result DeactivatePreference(long preferenceId)
+        {
+            var preference = _preferenceRepository.GetById(preferenceId);
+            if (preference == null)
+            {
+                return Result.Fail("Preference not found.");
+            }
+
+            preference.Deactivate();
+            _preferenceRepository.Update(preference);
+            return Result.Ok();
+        }
+
+        public Result DeletePreference(long preferenceId)
+        {
+            var preference = _preferenceRepository.GetById(preferenceId);
+            if (preference == null)
+            {
+                return Result.Fail("Preference not found.");
+            }
+
+            _preferenceRepository.Delete(preferenceId);
+            return Result.Ok();
+        }
+
+        public Result<List<PreferenceDto>> GetAllByTouristId(long touristId)
+        {
+            var allPreferences = _preferenceRepository.GetAll()
+;
+            if (allPreferences == null || !allPreferences.Any())
+            {
+                return Result.Fail<List<PreferenceDto>>("No preferences found.");
+            }
+
+            var userPreferences = allPreferences.Where(p => p.TouristId == touristId).ToList();
+
+            if (!userPreferences.Any())
+            {
+                return Result.Fail<List<PreferenceDto>>("No preferences found for this tourist.");
+            }
+
+            var preferenceDtos = _mapper.Map<List<PreferenceDto>>(userPreferences);
+
+            return Result.Ok(preferenceDtos);
+        }
+
     }
 
 

--- a/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/Repositories/PreferenceRepository.cs
+++ b/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/Repositories/PreferenceRepository.cs
@@ -1,0 +1,77 @@
+﻿using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.BuildingBlocks.Infrastructure.Database;
+using Explorer.Preferences.Core.Domain;
+using Explorer.Preferences.Core.Domain.RepositoryInterfaces;
+using Explorer.Tours.Core.Domain;
+using Explorer.Tours.Infrastructure.Database;
+using FluentResults;
+using Microsoft.EntityFrameworkCore;
+
+namespace Explorer.Preferences.Infrastructure.Database.Repositories;
+
+public class PreferenceRepository : CrudDatabaseRepository<Preference, ToursContext>, IPreferenceRepository
+{
+    private readonly ToursContext _dbContext;
+
+    public PreferenceRepository(ToursContext dbContext) : base(dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Preference? GetById(long id)
+    {
+        return _dbContext.Preferences
+            .Where(p => p.Id == id)
+            .FirstOrDefault();
+    }
+
+    public Preference AddPreference(Preference preference)
+    {
+        _dbContext.Preferences.Add(preference);
+        _dbContext.SaveChanges();
+        return preference;
+    }
+
+    public Result ActivatePreference(long preferenceId)
+    {
+        var preference = _dbContext.Preferences.FirstOrDefault(p => p.Id == preferenceId);
+        if (preference == null)
+        {
+            return Result.Fail("Preference not found.");
+        }
+
+        preference.Activate();
+        _dbContext.Entry(preference).State = EntityState.Modified;
+        _dbContext.SaveChanges();
+
+        return Result.Ok();
+    }
+
+    public Result DeactivatePreference(long preferenceId)
+    {
+        var preference = _dbContext.Preferences.FirstOrDefault(p => p.Id == preferenceId);
+        if (preference == null)
+        {
+            return Result.Fail("Preference not found.");
+        }
+
+        preference.Deactivate();
+        _dbContext.Entry(preference).State = EntityState.Modified;
+        _dbContext.SaveChanges();
+
+        return Result.Ok();
+    }
+
+    public List<Preference> GetByTouristId(long touristId)
+    {
+        return _dbContext.Preferences
+            .Where(p => p.TouristId == touristId)
+            .ToList();
+    }
+
+    public List<Preference> GetAll()
+    {
+        return _dbContext.Preferences.ToList();
+    }
+
+}

--- a/src/Modules/Tours/Explorer.Tours.Infrastructure/ToursStartup.cs
+++ b/src/Modules/Tours/Explorer.Tours.Infrastructure/ToursStartup.cs
@@ -1,5 +1,7 @@
 using Explorer.BuildingBlocks.Core.UseCases;
 using Explorer.BuildingBlocks.Infrastructure.Database;
+using Explorer.Preferences.Core.Domain.RepositoryInterfaces;
+using Explorer.Preferences.Infrastructure.Database.Repositories;
 using Explorer.Tours.API.Internal;
 using Explorer.Tours.API.Public;
 using Explorer.Tours.API.Public.Administration;
@@ -56,8 +58,10 @@ public static class ToursStartup
         services.AddScoped<ITourExecutionRepository, TourExecutionRepository>();
         services.AddScoped<ITourReviewRepository, TourReviewDatabaseRepository>();
         services.AddScoped<ICrudRepository<TourReview>>(sp => sp.GetRequiredService<ITourReviewRepository>());
+        services.AddScoped<IPreferenceRepository, PreferenceRepository>();
 
-		services.AddDbContext<ToursContext>(opt =>
+
+        services.AddDbContext<ToursContext>(opt =>
             opt.UseNpgsql(DbConnectionStringBuilder.Build("tours"),
                 x => x.MigrationsHistoryTable("__EFMigrationsHistory", "tours")));
     }

--- a/src/Modules/Tours/Explorer.Tours.Tests/Integration/Tourist/PreferenceCommandTests.cs
+++ b/src/Modules/Tours/Explorer.Tours.Tests/Integration/Tourist/PreferenceCommandTests.cs
@@ -6,6 +6,7 @@ using Explorer.Tours.Infrastructure.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
+using Explorer.Tours.API.Enum;
 
 namespace Explorer.Tours.Tests.Integration.Tourist
 {
@@ -29,7 +30,7 @@ namespace Explorer.Tours.Tests.Integration.Tourist
             var newPreference = new PreferenceDto
             {
                 TouristId = -11,
-                PreferredDifficulty = TourDifficulty.INTERMEDIATE,
+                PreferredDifficulty = TourLevel.Intermediate,
                 WalkRating = 3,
                 BikeRating = 2,
                 CarRating = 1,
@@ -53,7 +54,7 @@ namespace Explorer.Tours.Tests.Integration.Tourist
             var storedPreference = dbContext.Preferences.FirstOrDefault(p => p.TouristId == newPreference.TouristId);
             storedPreference.ShouldNotBeNull();
             storedPreference.TouristId.ShouldBe(result.TouristId);
-            storedPreference.PreferredDifficulty.ShouldBe(Preference.TourDifficulty.INTERMEDIATE);
+            storedPreference.PreferredDifficulty.ShouldBe(TourLevel.Intermediate);
         }
 
         [Fact]
@@ -65,7 +66,7 @@ namespace Explorer.Tours.Tests.Integration.Tourist
             var updatedPreference = new PreferenceDto
             {
                 TouristId = -1, // Invalid ID, dobro je, 
-                PreferredDifficulty = TourDifficulty.ADVANCED,
+                PreferredDifficulty = TourLevel.Advanced,
                 WalkRating = 3,
                 BikeRating = 3,
                 CarRating = 2,
@@ -95,7 +96,7 @@ namespace Explorer.Tours.Tests.Integration.Tourist
             {
                 Id = 735331,
                 TouristId = 1,
-                PreferredDifficulty = TourDifficulty.INTERMEDIATE,
+                PreferredDifficulty = TourLevel.Intermediate,
                 WalkRating = 3,
                 BikeRating = 2,
                 CarRating = 1,


### PR DESCRIPTION
## Change goal
-As a tourist, I want to set only one active preference at a time, so that I can receive tailored recommendations for tours that align with my current interest.

Acceptance Criteria

-A user can have only one active preference at any given time.
-When a new preference is activated, the previously active preference is automatically deactivated.
-Users can view a list of available preferences.

## Database change
- Added isActive field to preferences table.
